### PR TITLE
Bump prettier-plugin-toml to 2.0.1.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,8 +84,7 @@ dependencies {
 
 node {
   download = true
-  version = libs.versions.nodejs.get()
-  workDir = file("${buildDir}/nodejs")
+  workDir = layout.buildDirectory.dir("nodejs")
 }
 
 fun isNonStable(version: String): Boolean {
@@ -131,7 +130,13 @@ spotless {
     prettier(mapOf("prettier-plugin-toml" to libs.versions.prettier.toml.get()))
         .npmInstallCache()
         .nodeExecutable(computeNodeExec(node, computeNodeDir(node)).get())
-        .config(mapOf("parser" to "toml", "printWidth" to 100))
+        .config(
+            mapOf(
+                "plugins" to listOf("prettier-plugin-toml"),
+                "parser" to "toml",
+                "alignComments" to false,
+                "printWidth" to 100,
+            ))
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,11 +13,11 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+
 [versions]
 java-jdk = "11"
 kotlin = "2.0.0-RC2"
-nodejs = "20.5.1"
-prettier-toml = "0.3.1"
+prettier-toml = "2.0.1"
 
 [plugins]
 detekt = { id = "io.gitlab.arturbosch.detekt", version = "1.23.6" }


### PR DESCRIPTION
This is not visible to dependabot and must be done manually. This also requires a change to prettier's plugin loading and a configuration option to retain layout compatibility. We also use the node plugin default version of node.js.