### PR TITLE
221 migrate to new central publishing

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -19,6 +19,7 @@ Konstraints is developed by [AQUA Group](https://aqua.cs.tu-dortmund.de/) at TU 
 - Simon Dierl
 - Falk Howar
 - Laurenz Levi Spielmann
+- Richard Stewing
 
 ### Past Developers
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
   implementation(libs.gradle.kotlin.dokka)
   implementation(libs.gradle.kotlin.jvm)
   implementation(libs.gradle.kotlin.serialization)
-  implementation(libs.gradle.nexus.publish)
+  implementation(libs.gradle.vanniktech.maven.publish)
   implementation(libs.gradle.node)
   implementation(libs.gradle.spotless)
   implementation(libs.gradle.taskTree)

--- a/buildSrc/src/main/kotlin/konstraints.kotlin-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/konstraints.kotlin-library.gradle.kts
@@ -17,7 +17,6 @@
  */
 
 import org.gradle.accessors.dm.LibrariesForLibs
-import org.gradle.api.plugins.JavaBasePlugin.DOCUMENTATION_GROUP
 import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 
 plugins {
@@ -25,7 +24,6 @@ plugins {
   kotlin("jvm")
 
   id("org.jetbrains.dokka")
-  id("org.jetbrains.dokka-javadoc")
 }
 
 val libs = the<LibrariesForLibs>()
@@ -38,31 +36,7 @@ dependencies {
   testRuntimeOnly(libs.junit.launcher)
 }
 
-val kdocJar: TaskProvider<Jar> by
-    tasks.registering(Jar::class) {
-      group = DOCUMENTATION_GROUP
-      archiveClassifier = "kdoc"
-      from(tasks.dokkaGeneratePublicationHtml.flatMap { it.outputDirectory })
-    }
-
-val kdoc: Configuration by
-    configurations.creating {
-      isCanBeConsumed = true
-      isCanBeResolved = false
-    }
-
-artifacts { add(kdoc.name, kdocJar) }
-
-tasks.register("javadocJar", Jar::class) {
-  group = DOCUMENTATION_GROUP
-  archiveClassifier = "javadoc"
-  from(tasks.dokkaGeneratePublicationJavadoc.flatMap { it.outputDirectory })
-}
-
-java {
-  withJavadocJar()
-  withSourcesJar()
-}
+java { withSourcesJar() }
 
 kotlin { jvmToolchain(libs.versions.java.jdk.get().toInt()) }
 
@@ -70,3 +44,11 @@ tasks.test {
   useJUnitPlatform()
   testLogging { events(FAILED, SKIPPED, PASSED) }
 }
+
+// Avoid generating Dokka HTML publication pages during local publishing.
+// The javadoc jar produced for Maven publishing does not require these tasks.
+tasks
+    .matching {
+      it.name == "dokkaGeneratePublicationHtml" || it.name == "logLinkDokkaGeneratePublicationHtml"
+    }
+    .configureEach { enabled = false }

--- a/buildSrc/src/main/kotlin/konstraints.kotlin-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/konstraints.kotlin-library.gradle.kts
@@ -32,11 +32,15 @@ val libs = the<LibrariesForLibs>()
 
 repositories { mavenCentral() }
 
+java { toolchain { languageVersion = JavaLanguageVersion.of(libs.versions.java.jdk.get()) } }
+
 dependencies {
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.junit.jupiter)
   testRuntimeOnly(libs.junit.launcher)
 }
+
+dokka { dokkaGeneratorIsolation = ProcessIsolation { maxHeapSize = "4g" } }
 
 val kdocJar: TaskProvider<Jar> by
     tasks.registering(Jar::class) {
@@ -52,17 +56,6 @@ val kdoc: Configuration by
     }
 
 artifacts { add(kdoc.name, kdocJar) }
-
-tasks.register("javadocJar", Jar::class) {
-  group = DOCUMENTATION_GROUP
-  archiveClassifier = "javadoc"
-  from(tasks.dokkaGeneratePublicationJavadoc.flatMap { it.outputDirectory })
-}
-
-java {
-  withJavadocJar()
-  withSourcesJar()
-}
 
 kotlin { jvmToolchain(libs.versions.java.jdk.get().toInt()) }
 

--- a/buildSrc/src/main/kotlin/konstraints.kotlin-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/konstraints.kotlin-library.gradle.kts
@@ -17,6 +17,7 @@
  */
 
 import org.gradle.accessors.dm.LibrariesForLibs
+import org.gradle.api.plugins.JavaBasePlugin.DOCUMENTATION_GROUP
 import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 
 plugins {
@@ -24,6 +25,7 @@ plugins {
   kotlin("jvm")
 
   id("org.jetbrains.dokka")
+  id("org.jetbrains.dokka-javadoc")
 }
 
 val libs = the<LibrariesForLibs>()
@@ -36,7 +38,31 @@ dependencies {
   testRuntimeOnly(libs.junit.launcher)
 }
 
-java { withSourcesJar() }
+val kdocJar: TaskProvider<Jar> by
+    tasks.registering(Jar::class) {
+      group = DOCUMENTATION_GROUP
+      archiveClassifier = "kdoc"
+      from(tasks.dokkaGeneratePublicationHtml.flatMap { it.outputDirectory })
+    }
+
+val kdoc: Configuration by
+    configurations.creating {
+      isCanBeConsumed = true
+      isCanBeResolved = false
+    }
+
+artifacts { add(kdoc.name, kdocJar) }
+
+tasks.register("javadocJar", Jar::class) {
+  group = DOCUMENTATION_GROUP
+  archiveClassifier = "javadoc"
+  from(tasks.dokkaGeneratePublicationJavadoc.flatMap { it.outputDirectory })
+}
+
+java {
+  withJavadocJar()
+  withSourcesJar()
+}
 
 kotlin { jvmToolchain(libs.versions.java.jdk.get().toInt()) }
 
@@ -44,11 +70,3 @@ tasks.test {
   useJUnitPlatform()
   testLogging { events(FAILED, SKIPPED, PASSED) }
 }
-
-// Avoid generating Dokka HTML publication pages during local publishing.
-// The javadoc jar produced for Maven publishing does not require these tasks.
-tasks
-    .matching {
-      it.name == "dokkaGeneratePublicationHtml" || it.name == "logLinkDokkaGeneratePublicationHtml"
-    }
-    .configureEach { enabled = false }

--- a/buildSrc/src/main/kotlin/konstraints.maven-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/konstraints.maven-library.gradle.kts
@@ -23,8 +23,7 @@ import tools.aqua.commonSetup
 
 plugins {
   `java-library`
-  `maven-publish`
-  signing
+  id("com.vanniktech.maven.publish")
 }
 
 val libs = the<LibrariesForLibs>()
@@ -35,16 +34,11 @@ java { toolchain { languageVersion = JavaLanguageVersion.of(libs.versions.java.j
 
 val metadata = project.extensions.create<MetadataExtension>("metadata")
 
-publishing.publications.withType(MavenPublication::class).configureEach {
-  pom { commonSetup(metadata) }
-}
-
-if (plugins.hasPlugin("com.vanniktech.maven.publish").not()) {
-  publishing.publications.create("maven", MavenPublication::class) { from(components["java"]) }
-}
-
-signing {
-  setRequired { gradle.taskGraph.allTasks.any { it is PublishToMavenRepository } }
-  useGpgCmd()
-  sign(publishing.publications)
+mavenPublishing {
+  publishToMavenCentral()
+  signAllPublications()
+  pom {
+    commonSetup(metadata)
+    metadata.packaging.orNull?.let { packaging = it }
+  }
 }

--- a/buildSrc/src/main/kotlin/konstraints.maven-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/konstraints.maven-library.gradle.kts
@@ -17,6 +17,7 @@
  */
 
 import org.gradle.accessors.dm.LibrariesForLibs
+import org.gradle.api.publish.tasks.GenerateModuleMetadata
 import org.gradle.kotlin.dsl.*
 import tools.aqua.MetadataExtension
 import tools.aqua.commonSetup
@@ -41,4 +42,8 @@ mavenPublishing {
     commonSetup(metadata)
     metadata.packaging.orNull?.let { packaging = it }
   }
+}
+
+tasks.withType<GenerateModuleMetadata>().configureEach {
+  dependsOn(tasks.matching { it.name == "dokkaJavadocJar" })
 }

--- a/buildSrc/src/main/kotlin/konstraints.maven-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/konstraints.maven-library.gradle.kts
@@ -35,15 +35,16 @@ java { toolchain { languageVersion = JavaLanguageVersion.of(libs.versions.java.j
 
 val metadata = project.extensions.create<MetadataExtension>("metadata")
 
-val maven by
-    publishing.publications.creating(MavenPublication::class) {
-      from(components["java"])
+publishing.publications.withType(MavenPublication::class).configureEach {
+  pom { commonSetup(metadata) }
+}
 
-      pom { commonSetup(metadata) }
-    }
+if (plugins.hasPlugin("com.vanniktech.maven.publish").not()) {
+  publishing.publications.create("maven", MavenPublication::class) { from(components["java"]) }
+}
 
 signing {
   setRequired { gradle.taskGraph.allTasks.any { it is PublishToMavenRepository } }
   useGpgCmd()
-  sign(maven)
+  sign(publishing.publications)
 }

--- a/buildSrc/src/main/kotlin/konstraints.maven-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/konstraints.maven-library.gradle.kts
@@ -17,7 +17,6 @@
  */
 
 import org.gradle.accessors.dm.LibrariesForLibs
-import org.gradle.api.publish.tasks.GenerateModuleMetadata
 import org.gradle.kotlin.dsl.*
 import tools.aqua.MetadataExtension
 import tools.aqua.commonSetup
@@ -42,8 +41,4 @@ mavenPublishing {
     commonSetup(metadata)
     metadata.packaging.orNull?.let { packaging = it }
   }
-}
-
-tasks.withType<GenerateModuleMetadata>().configureEach {
-  dependsOn(tasks.matching { it.name == "dokkaJavadocJar" })
 }

--- a/buildSrc/src/main/kotlin/konstraints.maven-pom.gradle.kts
+++ b/buildSrc/src/main/kotlin/konstraints.maven-pom.gradle.kts
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 
-import com.vanniktech.maven.publish.JavadocJar.Dokka
-import com.vanniktech.maven.publish.KotlinJvm
-import org.jetbrains.dokka.gradle.tasks.DokkaGenerateModuleTask
+import com.vanniktech.maven.publish.JavaLibrary
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.SourcesJar
 import tools.aqua.MetadataExtension
 import tools.aqua.commonSetup
 
@@ -32,20 +32,11 @@ mavenPublishing {
   publishToMavenCentral()
   signAllPublications()
 
-  configure(
-      KotlinJvm(
-          Dokka(tasks.named("dokkaGenerateModuleJavadoc")),
-      )
-  )
+  // unfortunately, we have to add an empty JAR in this step due to Gradle / Vanniktech limitations
+  configure(JavaLibrary(JavadocJar.None(), SourcesJar.None()))
 
-  // add kdoc artifact
-  val kdocJar =
-      tasks.register<Jar>("dokkaKdocJar") {
-        archiveClassifier = "kdoc"
-        val dokkaTask = tasks.named<DokkaGenerateModuleTask>("dokkaGenerateModuleHtml")
-        from(dokkaTask.flatMap { it.outputDirectory })
-      }
-  project.publishing.publications.named<MavenPublication>("maven").configure { artifact(kdocJar) }
-
-  pom { commonSetup(metadata) }
+  pom {
+    packaging = "pom"
+    commonSetup(metadata)
+  }
 }

--- a/buildSrc/src/main/kotlin/konstraints.pom.gradle.kts
+++ b/buildSrc/src/main/kotlin/konstraints.pom.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2023-2024 The Konstraints Authors
+ * Copyright 2023-2026 The Konstraints Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,13 @@
  * limitations under the License.
  */
 
-plugins {
-  `java-library`
-  id("konstraints.developer-utilities")
-  id("konstraints.maven-pom")
-  id("konstraints.pom")
-}
+import org.gradle.accessors.dm.LibrariesForLibs
+import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 
-metadata {
-  name = "Konstraints Full Bundle"
-  description = "The Konstraints library and all accompanying solver plugins"
-}
+plugins { `java-library` }
 
-dependencies {
-  api(project(":konstraints-core"))
-  api(project(":konstraints-z3"))
-}
+val libs = the<LibrariesForLibs>()
+
+repositories { mavenCentral() }
+
+java { toolchain { languageVersion = JavaLanguageVersion.of(libs.versions.java.jdk.get()) } }

--- a/buildSrc/src/main/kotlin/konstraints.root-setup.gradle.kts
+++ b/buildSrc/src/main/kotlin/konstraints.root-setup.gradle.kts
@@ -16,12 +16,7 @@
  * limitations under the License.
  */
 
-import org.gradle.kotlin.dsl.repositories
-
-plugins {
-  id("io.github.gradle-nexus.publish-plugin")
-  id("me.qoomon.git-versioning")
-}
+plugins { id("me.qoomon.git-versioning") }
 
 allprojects { group = "tools.aqua" }
 
@@ -52,5 +47,3 @@ gitVersioning.apply {
     version = "0.0.0-unknown-0-\${commit.short}-SNAPSHOT"
   }
 }
-
-nexusPublishing { this.repositories { sonatype() } }

--- a/buildSrc/src/main/kotlin/tools/aqua/metadata.kt
+++ b/buildSrc/src/main/kotlin/tools/aqua/metadata.kt
@@ -26,4 +26,6 @@ interface MetadataExtension {
   val name: Property<String>
   /** The project's human-readable description. */
   val description: Property<String>
+  /** Optional POM packaging, e.g. `pom` for aggregator modules. */
+  val packaging: Property<String>
 }

--- a/buildSrc/src/main/kotlin/tools/aqua/metadata.kt
+++ b/buildSrc/src/main/kotlin/tools/aqua/metadata.kt
@@ -26,6 +26,4 @@ interface MetadataExtension {
   val name: Property<String>
   /** The project's human-readable description. */
   val description: Property<String>
-  /** Optional POM packaging, e.g. `pom` for aggregator modules. */
-  val packaging: Property<String>
 }

--- a/buildSrc/src/main/kotlin/tools/aqua/pom.kt
+++ b/buildSrc/src/main/kotlin/tools/aqua/pom.kt
@@ -56,6 +56,11 @@ fun MavenPom.commonSetup(metadata: MetadataExtension) {
       email.set("laurenz-levi.spielmann@tu-dortmund.de")
       organization.set("TU Dortmund University")
     }
+    developer {
+      name.set("Richard Stewing")
+      email.set("richard.stewing@tu-dortmund.de")
+      organization.set("TU Dortmund University")
+    }
   }
 
   scm {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,10 @@ java-jdk = "11"
 kotlin = "2.2.21"
 prettier-toml = "2.0.1"
 
+[plugins]
+
+mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.36.0" }
+
 [libraries]
 # gradle plugins
 gradle-detekt = { group = "io.gitlab.arturbosch.detekt", name = "detekt-gradle-plugin", version = "1.23.8" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,10 +19,6 @@ java-jdk = "11"
 kotlin = "2.2.21"
 prettier-toml = "2.0.1"
 
-[plugins]
-
-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.36.0" }
-
 [libraries]
 # gradle plugins
 gradle-detekt = { group = "io.gitlab.arturbosch.detekt", name = "detekt-gradle-plugin", version = "1.23.8" }
@@ -30,7 +26,7 @@ gradle-gitVersioning = { group = "me.qoomon", name = "gradle-git-versioning-plug
 gradle-kotlin-dokka = { group = "org.jetbrains.dokka", name = "dokka-gradle-plugin", version = "2.1.0" }
 gradle-kotlin-jvm = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 gradle-kotlin-serialization = { group = "org.jetbrains.kotlin", name = "kotlin-serialization", version.ref = "kotlin" }
-gradle-nexus-publish = { group = "io.github.gradle-nexus", name = "publish-plugin", version = "2.0.0" }
+gradle-vanniktech-maven-publish = { group = "com.vanniktech", name = "gradle-maven-publish-plugin", version = "0.36.0" }
 gradle-node = { group = "com.github.node-gradle", name = "gradle-node-plugin", version = "7.1.0" }
 gradle-spotless = { group = "com.diffplug.spotless", name = "spotless-plugin-gradle", version = "8.3.0" }
 gradle-taskTree = { group = "com.dorongold.plugins", name = "task-tree", version = "4.0.0" }

--- a/konstraints-all/build.gradle.kts
+++ b/konstraints-all/build.gradle.kts
@@ -16,13 +16,7 @@
  * limitations under the License.
  */
 
-import tools.aqua.commonSetup
-
 plugins {
-  `maven-publish`
-
-  alias(libs.plugins.mavenPublish)
-
   id("konstraints.developer-utilities")
   id("konstraints.maven-library")
 }
@@ -30,24 +24,10 @@ plugins {
 metadata {
   name = "Konstraints Full Bundle"
   description = "The Konstraints library and all accompanying solver plugins"
+  packaging = "pom"
 }
 
 dependencies {
   api(project(":konstraints-core"))
   api(project(":konstraints-z3"))
 }
-
-publishing.publications.withType(MavenPublication::class) {
-  pom { packaging = "pom" }
-}
-
-mavenPublishing {
-  publishToMavenCentral()
-  signAllPublications()
-
-  pom {
-    commonSetup(metadata)
-  }
-}
-
-signing { useGpgCmd() }

--- a/konstraints-all/build.gradle.kts
+++ b/konstraints-all/build.gradle.kts
@@ -16,7 +16,13 @@
  * limitations under the License.
  */
 
+import tools.aqua.commonSetup
+
 plugins {
+  `maven-publish`
+
+  alias(libs.plugins.mavenPublish)
+
   id("konstraints.developer-utilities")
   id("konstraints.maven-library")
 }
@@ -34,3 +40,14 @@ dependencies {
 publishing.publications.withType(MavenPublication::class) {
   pom { packaging = "pom" }
 }
+
+mavenPublishing {
+  publishToMavenCentral()
+  signAllPublications()
+
+  pom {
+    commonSetup(metadata)
+  }
+}
+
+signing { useGpgCmd() }


### PR DESCRIPTION
## PR Description

  This PR moves to a modern Maven Central publishing plugin (vanniktech.maven.publish).

  ### Changes

  - Unified publishing configuration around one plugin/workflow for library and BOM/POM-style artifacts.
  - Updated project build conventions so publication metadata and artifact setup are applied more consistently.
  - Simplified root publishing setup by removing legacy Sonatype/nexus-specific wiring.
  - Added/updated project contributor metadata.

  ### Why

- nexus.publish is not compatible with Maven Central any longer.


  ### Impact

  - Affects build/release infrastructure and publication metadata.
  - No intended runtime/API behavior changes to the libraries themselves.